### PR TITLE
fix: Use version tag instead of :main in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,8 @@ jobs:
       contents: read
       packages: write
       security-events: write
+    outputs:
+      version: ${{ steps.pkg_version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
@@ -142,6 +144,10 @@ jobs:
             git checkout -- docker-compose.yml
             git checkout main
             git pull
+
+            echo "📋 Actualizando imagen a versión ${{ needs.build-and-push.outputs.version }}..."
+            sed -i 's|image: ghcr.io/monghit-server/test-deploy:.*|image: ghcr.io/monghit-server/test-deploy:${{ needs.build-and-push.outputs.version }}|' docker-compose.yml
+
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose pull
             docker compose up -d

--- a/README.md
+++ b/README.md
@@ -288,8 +288,10 @@ test-deploy/
 Se ejecuta en push a main:
 
 1. **create-tag**: Crea tag automatico basado en `package.json`
-2. **build-and-push**: Construye y sube imagen a ghcr.io
-3. **deploy**: Despliega en el servidor via SSH
+2. **build-and-push**: Construye y sube imagen a ghcr.io (exporta la version como output)
+3. **deploy**: Despliega en el servidor via SSH usando el tag de version especifico
+
+El deploy actualiza el `docker-compose.yml` en el servidor para usar el tag de version (ej: `:1.1.5`) en lugar de `:main`. Esto evita acumular imagenes sin tag (dangling) en el servidor.
 
 Cada job envia una notificacion a Telegram si falla.
 
@@ -336,8 +338,14 @@ Cada build crea tres tags en ghcr.io:
 
 ### Gestion de Imagenes
 
-Las imagenes se almacenan en ghcr.io y se descargan al servidor en cada deploy. Para limpiar imagenes locales no utilizadas:
+Las imagenes se almacenan en ghcr.io y se descargan al servidor en cada deploy.
 
+**Tags de version en el servidor:**
+El deploy actualiza automaticamente el `docker-compose.yml` del servidor para usar el tag de version especifico (ej: `:1.1.5`). Esto tiene dos ventajas:
+- Evita acumular imagenes sin tag (dangling) que ocupan espacio
+- Permite saber exactamente que version esta corriendo en el servidor
+
+**Limpieza manual (si es necesario):**
 ```bash
 # Eliminar imagenes sin tag (dangling)
 docker image prune -f

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-deploy",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Test deploy app",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Add outputs to build-and-push job to export version
- Update docker-compose.yml on server with specific version tag
- This prevents dangling images on the server
- Bump version to 1.1.5